### PR TITLE
Handle SerialException for Daktronic Consoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     basketball = Basketball('COM1')
     game_state = basketball.export()
 ```
-*Call to sport class must be protected by an `if __name__ == '__main__'` because the serial connection is read in a seperate process*
+*Calls to sport class must be protected by an `if __name__ == '__main__'` because the serial connection is read in a seperate process*
 
 ### Connecting a Console
 Consoles are connected with via a Serial to USB cable.
@@ -33,7 +33,26 @@ Consoles are connected with via a Serial to USB cable.
 **Colorado Time Systems System 6** - Tap into the 1/4" Scoreboard Out plug and connect the tip to pin 2 of a Serial DB9 connector and the shoe to pin 5.
 
 ### API
-Sport classes take a serial port string as an argument and expose an `export` method that returns the current game state.
+Sport classes take a serial port string as an argument and expose an `export` method that returns the current game state.  All sport classes also feature an `on_update` method that is designed to be reimplemented.  It is called everytime the state of the game changes, depending on the settings of the console, this can work out to be 10 times per second or faster.  `on_update` must take a single variable, a Python dictionary that corresponds to the game state values described below for each sport.
+```python
+from consoles.sports import Football
+
+def do_something(game_state):
+    # Do something useful with the parse score console information
+    # For example:
+    home = game_state['home_score']
+    visitor = game_state['visitor_score']
+    if home > visitor:
+        print(f'The Home Team leads {home} to {visitor}.')
+    elif visitor > home:
+        print(f'The Visiting Team leads {visitor} to {home}.')
+    else:
+        print(f'The teams are tied at {home}')
+
+if __name__ == '__main__':
+    football = Football('COM1')
+    football.on_update = do_something
+```
 
 #### :basketball: Basketball
 | Key | Type | Description |
@@ -76,3 +95,4 @@ Sport classes take a serial port string as an argument and expose an `export` me
 | `clock` | str | Main Clock Time |
 | `shot` | str | Shot Clock Time |
 | `period` | str | Game Period |
+*Water Polo is supported on both Daktronics and Colorado Time Systems consoles: for Daktronics call `WaterPoloDaktronics`, for Colorado Time Systems call `WaterPolo`*

--- a/README.md
+++ b/README.md
@@ -95,4 +95,5 @@ if __name__ == '__main__':
 | `clock` | str | Main Clock Time |
 | `shot` | str | Shot Clock Time |
 | `period` | str | Game Period |
+
 *Water Polo is supported on both Daktronics and Colorado Time Systems consoles: for Daktronics call `WaterPoloDaktronics`, for Colorado Time Systems call `WaterPolo`*

--- a/consoles/daktronics.py
+++ b/consoles/daktronics.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 import serial
 from serial import PARITY_NONE
+from serial.serialutil import SerialException 
 from multiprocessing.connection import Connection
 
 from . import SerialConnection
@@ -37,7 +38,10 @@ class Daktronics (SerialConnection):
             # Filter out 'SYNC IDLE' transmissions
             control_character = 0
             while control_character != b'\x16':
-                control_character = connection.read()
+                try:
+                    control_character = connection.read()
+                except SerialException:
+                    continue
             message = ''
             last_character = b''
             # Real Time Data Messages end with a 'END TRANSMISSION BLOCK'
@@ -48,5 +52,8 @@ class Daktronics (SerialConnection):
                     message += chr(dec)
                 else:
                     pass
-                last_character = connection.read()
+                try:
+                    last_character = connection.read()
+                except SerialException:
+                    continue
             self.parse(message)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="scorebox-consoles",
-    version="1.1.0",
+    version="1.1.1",
     author="Daniel Flanagan",
     description="Python interface for scoreboard consoles manufactured by Daktronics and Colorado Time Systems",
     long_description=long_description,


### PR DESCRIPTION
There is a critical bug that effects the serial connection to all Daktronic consoles:

In the event of a momentary loss of connection to the serial port, either via physical disconnection or software disconnect, ScoreBox Consoles fails to recover.

Here is a `dmesg` log and it's related ScoreBox Consoles thrown exception:
```
[  309.135062] pl2303 ttyUSB0: usb_serial_generic_read_bulk_callback - urb stopped: -32
[  309.143385] pl2303 ttyUSB0: usb_serial_generic_read_bulk_callback - urb stopped: -32
[  309.383168] usb 1-1.3: USB disconnect, device number 3
[  309.383786] pl2303 ttyUSB0: pl2303_set_control_lines - failed: -19
[  309.390093] pl2303 ttyUSB0: error sending break = -19
[  309.395986] pl2303 ttyUSB0: pl2303 converter now disconnected from ttyUSB0
[  309.396029] pl2303 1-1.3:1.0: device disconnected
[  309.618487] usb 1-1.3: new full-speed USB device number 4 using xhci_hcd
[  309.724456] usb 1-1.3: New USB device found, idVendor=067b, idProduct=2303, bcdDevice= 3.00
[  309.724472] usb 1-1.3: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[  309.724484] usb 1-1.3: Product: USB-Serial Controller
[  309.724495] usb 1-1.3: Manufacturer: Prolific Technology Inc.
[  309.727219] pl2303 1-1.3:1.0: pl2303 converter detected
[  309.736174] usb 1-1.3: pl2303 converter now attached to ttyUSB0
```

```
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/GitHub/scorebox-relay/venv/lib/python3.9/site-packages/consoles/__init__.py", line 31, in run
    self.update(send_pipe, connection)
  File "/home/ubuntu/GitHub/scorebox-relay/venv/lib/python3.9/site-packages/consoles/daktronics.py", line 40, in update
    control_character = connection.read()
  File "/home/ubuntu/GitHub/scorebox-relay/venv/lib/python3.9/site-packages/serial/serialposix.py", line 595, in read
    raise SerialException(
serial.serialutil.SerialException: device reports readiness to read but returned no data (device disconnected or multiple access on port?)
```

This pull request handles the exception gracefully and prevents a crash.